### PR TITLE
handle case where start and end points are the same

### DIFF
--- a/crdp.pyx
+++ b/crdp.pyx
@@ -17,7 +17,10 @@ cdef _c_rdp(double *x, double *y, int n, char* mask, double epsilon):
         dmax = 0.0
         index = st
         for i from st < i < ed:
-            d = abs(p0 * x[i] - p1 * y[i] + p2) / dis
+            if dis:
+                d = abs(p0 * x[i] - p1 * y[i] + p2) / dis
+            else:
+                d = sqrt((y[st]-y[i]) * (y[st]-y[i]) + (x[st]-x[i]) * (x[st]-x[i]))
             if d > dmax:
                 index = i
                 dmax = d


### PR DESCRIPTION
It's the issue referred here 
https://github.com/biran0079/crdp/issues/2

we have the case on on of the test .tcx files, so downsampling fail.

I copied the code as is, not sure if it's correct